### PR TITLE
Integrate Pattern Library with Monolith 4

### DIFF
--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -2,13 +2,13 @@
 
 
 // DEV ONLY: Get pattern-library scaffolding
-//@import '../../../../../../pattern-library/source/css/pattern-scaffolding';
-
-// Get pattern-library styles
-@import '../../../../../../pattern-library/source/css/style';
-
+@import '../../../../../../../pattern-library/source/css/pattern-scaffolding';
 
 @import 'settings';
+
+// Get pattern-library styles, with our settings applied
+@import '../../../../../../../pattern-library/source/css/style';
+
 @import 'foundation';
 @import 'motion-ui';
 

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -1,6 +1,9 @@
 @charset 'utf-8';
 
 
+// DEV ONLY: Get pattern-library scaffolding
+//@import '../../../../../../pattern-library/source/css/pattern-scaffolding';
+
 // Get pattern-library styles
 @import '../../../../../../pattern-library/source/css/style';
 

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -1,6 +1,10 @@
 @charset 'utf-8';
 
 
+// Get pattern-library styles
+@import '../../../../../../pattern-library/source/css/style';
+
+
 @import 'settings';
 @import 'foundation';
 @import 'motion-ui';


### PR DESCRIPTION
- Pattern Library should be installed to the root of the project
- Pull in twig templates from Pattern Library
- Pull in component styles from Pattern Library
- Pull in scaffolding styles (if required) from Pattern Library